### PR TITLE
Provide blocking and async versions of `pixel_rgb` methods.

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -108,11 +108,39 @@ where
         }
     }
 
-    pub fn pixel_rgb(&mut self, x: u8, y: u8, r: u8, g: u8, b: u8) -> Result<(), Error<I2cError>> {
+    pub fn pixel_rgb_blocking(
+        &mut self,
+        x: u8,
+        y: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
         let x = (4 * (3 - x)) + y;
-        self.device.pixel(x, 0, r)?;
-        self.device.pixel(x, 1, g)?;
-        self.device.pixel(x, 2, b)?;
+        self.device.pixel_blocking(x, 0, r)?;
+        self.device.pixel_blocking(x, 1, g)?;
+        self.device.pixel_blocking(x, 2, b)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "keybow_2040")]
+impl<I2C, I2cError> Keybow2040<I2C>
+where
+    I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
+{
+    pub async fn pixel_rgb(
+        &mut self,
+        x: u8,
+        y: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
+        let x = (4 * (3 - x)) + y;
+        self.device.pixel(x, 0, r).await?;
+        self.device.pixel(x, 1, g).await?;
+        self.device.pixel(x, 2, b).await?;
         Ok(())
     }
 }
@@ -207,10 +235,35 @@ where
             },
         }
     }
-    pub fn pixel_rgb(&mut self, x: u8, r: u8, g: u8, b: u8) -> Result<(), Error<I2cError>> {
-        self.device.pixel(x, 0, r)?;
-        self.device.pixel(x, 1, g)?;
-        self.device.pixel(x, 2, b)?;
+    pub fn pixel_rgb_blocking(
+        &mut self,
+        x: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
+        self.device.pixel_blocking(x, 0, r)?;
+        self.device.pixel_blocking(x, 1, g)?;
+        self.device.pixel_blocking(x, 2, b)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "led_shim")]
+impl<I2C, I2cError> LEDShim<I2C>
+where
+    I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
+{
+    pub async fn pixel_rgb_blocking(
+        &mut self,
+        x: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
+        self.device.pixel(x, 0, r).await?;
+        self.device.pixel(x, 1, g).await?;
+        self.device.pixel(x, 2, b).await?;
         Ok(())
     }
 }
@@ -276,11 +329,39 @@ where
         }
     }
 
-    pub fn pixel_rgb(&mut self, x: u8, y: u8, r: u8, g: u8, b: u8) -> Result<(), Error<I2cError>> {
+    pub fn pixel_rgb_blocking(
+        &mut self,
+        x: u8,
+        y: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
         let x = x + y * 5;
-        self.device.pixel(x, 0, r)?;
-        self.device.pixel(x, 1, g)?;
-        self.device.pixel(x, 2, b)?;
+        self.device.pixel_blocking(x, 0, r)?;
+        self.device.pixel_blocking(x, 1, g)?;
+        self.device.pixel_blocking(x, 2, b)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "rgb_matrix_5x5")]
+impl<I2C, I2cError> RGBMatrix5x5<I2C>
+where
+    I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
+{
+    pub async fn pixel_rgb(
+        &mut self,
+        x: u8,
+        y: u8,
+        r: u8,
+        g: u8,
+        b: u8,
+    ) -> Result<(), Error<I2cError>> {
+        let x = x + y * 5;
+        self.device.pixel(x, 0, r).await?;
+        self.device.pixel(x, 1, g).await?;
+        self.device.pixel(x, 2, b).await?;
         Ok(())
     }
 }

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -124,7 +124,7 @@ where
     }
 }
 
-#[cfg(feature = "keybow_2040")]
+#[cfg(all(feature = "keybow_2040", feature = "async"))]
 impl<I2C, I2cError> Keybow2040<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
@@ -249,7 +249,7 @@ where
     }
 }
 
-#[cfg(feature = "led_shim")]
+#[cfg(all(feature = "led_shim", feature = "async"))]
 impl<I2C, I2cError> LEDShim<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
@@ -345,7 +345,7 @@ where
     }
 }
 
-#[cfg(feature = "rgb_matrix_5x5")]
+#[cfg(all(feature = "rgb_matrix_5x5", feature = "async"))]
 impl<I2C, I2cError> RGBMatrix5x5<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -71,10 +71,7 @@ impl CharlieWing {
 }
 
 #[cfg(feature = "keybow_2040")]
-impl<I2C, I2cError> Keybow2040<I2C>
-where
-    I2C: Write<Error = I2cError>,
-{
+impl<I2C> Keybow2040<I2C> {
     pub fn configure(i2c: I2C) -> Self {
         Self {
             device: IS31FL3731 {
@@ -107,7 +104,13 @@ where
             },
         }
     }
+}
 
+#[cfg(feature = "keybow_2040")]
+impl<I2C, I2cError> Keybow2040<I2C>
+where
+    I2C: Write<Error = I2cError>,
+{
     pub fn pixel_rgb_blocking(
         &mut self,
         x: u8,
@@ -146,10 +149,7 @@ where
 }
 
 #[cfg(feature = "led_shim")]
-impl<I2C, I2cError> LEDShim<I2C>
-where
-    I2C: Write<Error = I2cError>,
-{
+impl<I2C> LEDShim<I2C> {
     pub fn configure(i2c: I2C) -> Self {
         Self {
             device: IS31FL3731 {
@@ -235,6 +235,13 @@ where
             },
         }
     }
+}
+
+#[cfg(feature = "led_shim")]
+impl<I2C, I2cError> LEDShim<I2C>
+where
+    I2C: Write<Error = I2cError>,
+{
     pub fn pixel_rgb_blocking(
         &mut self,
         x: u8,
@@ -254,13 +261,7 @@ impl<I2C, I2cError> LEDShim<I2C>
 where
     I2C: embedded_hal_async::i2c::I2c<Error = I2cError>,
 {
-    pub async fn pixel_rgb_blocking(
-        &mut self,
-        x: u8,
-        r: u8,
-        g: u8,
-        b: u8,
-    ) -> Result<(), Error<I2cError>> {
+    pub async fn pixel_rgb(&mut self, x: u8, r: u8, g: u8, b: u8) -> Result<(), Error<I2cError>> {
         self.device.pixel(x, 0, r).await?;
         self.device.pixel(x, 1, g).await?;
         self.device.pixel(x, 2, b).await?;
@@ -283,10 +284,7 @@ impl Matrix {
 }
 
 #[cfg(feature = "rgb_matrix_5x5")]
-impl<I2C, I2cError> RGBMatrix5x5<I2C>
-where
-    I2C: Write<Error = I2cError>,
-{
+impl<I2C> RGBMatrix5x5<I2C> {
     pub fn configure(i2c: I2C) -> Self {
         Self {
             device: IS31FL3731 {
@@ -328,7 +326,13 @@ where
             },
         }
     }
+}
 
+#[cfg(feature = "rgb_matrix_5x5")]
+impl<I2C, I2cError> RGBMatrix5x5<I2C>
+where
+    I2C: Write<Error = I2cError>,
+{
     pub fn pixel_rgb_blocking(
         &mut self,
         x: u8,


### PR DESCRIPTION
This also fixes an unsatisfied trait bound error.

Rename existing `pixel_rgb` methods to `pixel_rgb_blocking`, and update them to use `device.pixel_blocking` since async `device.pixel` is not available based on `I2C` constraints.

Add new `impl`s for async `pixel_rgb` methods, with async hal constraint on `I2C` to allow calling `device.pixel`.